### PR TITLE
Optimize and reuse Shared Heroes among components

### DIFF
--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -24,11 +24,18 @@ export class DashboardComponent implements OnInit {
   }
 
   getHeroes(): void {
-    this.heroesSubscription = this.heroService.getHeroes()
+    const sharedHeroes = this.heroService.getShareableHeroes();
+    if (sharedHeroes.length > 0){
+      this.heroes = sharedHeroes;
+      this.topHeroes = this.shuffleHeroes(this.heroes).slice(0, 4);
+    } else {
+      this.heroesSubscription = this.heroService.getHeroes()
       .subscribe(heroes => {
         this.heroes = heroes;
         this.topHeroes = this.shuffleHeroes(heroes).slice(0, 4);
+        this.heroService.setShareableHeroes(heroes);
       });
+    }
   }
 
   ngOnInit(): void {

--- a/src/app/hero.service.ts
+++ b/src/app/hero.service.ts
@@ -16,6 +16,16 @@ export class HeroService {
     private http: HttpClient,
   ) { }
 
+  private shareableHeroes: Hero[] = [];
+
+  setShareableHeroes(heroes: Hero[]): void {
+    this.shareableHeroes = heroes;
+  }
+
+  getShareableHeroes(): Hero[] {
+    return this.shareableHeroes;
+  }
+
   /** Log a HeroService message with the MessageService */
   private log(message: string) {
     this.messageService.add(`HeroService: ${message}`);

--- a/src/app/heroes/heroes.component.ts
+++ b/src/app/heroes/heroes.component.ts
@@ -26,7 +26,10 @@ export class HeroesComponent implements OnInit{
   
   getHeroes(): void {
     this.heroesSubscription = this.heroService.getHeroes()
-        .subscribe(heroes => this.heroes = heroes);
+        .subscribe(heroes => {
+          this.heroes = heroes;
+          this.heroService.setShareableHeroes(heroes);
+        });
   }
 
   add(name: string): void {


### PR DESCRIPTION
### Optimizations
- Create shareable heroes, can be get / set
- Set shareable heroes when dashboard component is first loaded
- Set shareable heroes when heroes component is always / every time it is loaded
- Get shared heroes when navigating back to dashboard instead of recalling another `getHeroes()` request

### Reasoning
- Dashboard should only once call `getHeroes()` upon first load OR reload
- Dashboard should reuse its heroes if user navigated to a hero detail component
- Dashboard should have a brand new heroes if user navigated to heroes component
- Heroes component should always call `getHeroes()` request and share this old / new heroes to dashboard component